### PR TITLE
wheel: improved rpm calculation for wheels

### DIFF
--- a/wheel/wheel.c
+++ b/wheel/wheel.c
@@ -16,6 +16,12 @@
 
 wheel_t wheel_create(motor_t w_motor, encoder_t w_encoder, controller_t w_controller, float radius, rt_uint16_t gear_ratio)
 {
+    //radius must not be zero, protect:
+    if(radius == 0.0f) 
+    {
+        return RT_NULL;
+    }
+
     // 1. Malloc memory for wheel
     wheel_t new_wheel = (wheel_t) rt_malloc(sizeof(struct wheel));
     if(new_wheel == RT_NULL)
@@ -111,7 +117,7 @@ rt_err_t wheel_set_speed(wheel_t whl, double speed)
 {
     RT_ASSERT(whl != RT_NULL);
 
-    return wheel_set_rpm(whl, (rt_int16_t) (speed / 60.0 / 2.0 / whl->radius / PI));
+    return wheel_set_rpm(whl, (rt_int16_t) (speed * whl->speed_to_rpm));
 }
 
 rt_err_t wheel_set_rpm(wheel_t whl, rt_int16_t rpm)

--- a/wheel/wheel.c
+++ b/wheel/wheel.c
@@ -31,6 +31,9 @@ wheel_t wheel_create(motor_t w_motor, encoder_t w_encoder, controller_t w_contro
     new_wheel -> radius       = radius;
     new_wheel -> gear_ratio   = gear_ratio;
 
+    // 3. pre compute the speed to rpm transform ;)
+    new_wheel -> speed_to_rpm = 1.0 / (w->radius * 2.0 * 60.0 * PI);
+
     return new_wheel;
 }
 
@@ -102,6 +105,8 @@ rt_err_t wheel_reset(wheel_t whl)
 }
 
 /** speed = rpm x 60 x 2 x PI x radius **/
+/** so : rpm = speed x 1.0f / (radius x 60 x 2 x PT) */
+/** then : rpm = speed * speed_to_rpm_transform --> precomputed */
 rt_err_t wheel_set_speed(wheel_t whl, double speed)
 {
     RT_ASSERT(whl != RT_NULL);

--- a/wheel/wheel.h
+++ b/wheel/wheel.h
@@ -28,6 +28,7 @@ struct wheel
 
     rt_int16_t      rpm;
     float           radius;
+    double          speed_to_rpm;
     rt_uint16_t     gear_ratio;
 };
 


### PR DESCRIPTION
I improved the wheel speed to rpm calculations by replacing the division to a pre-computed expression, then a reciprocal multiply was added. Using this scheme we gain speed in two perspectives:

1 - the speed to rpm constant is calculated only once, that is it when the wheel object is allocated;
2 - typical microcontrollers (and processors) have a single / two cycle multiplication instruction and its divistion instruction is non-deterministic, so where allowed I replaced the division by a reciprocal multiplication, this will hints the compiler to remove the division and add a simple multiplication in place speeding up the result and adding determinism to that.

Please let me know your thoughts.