### PR TITLE
1.将结构体中的struct kinematics中的wheel_radius修改为circumference，这种修改更为贴近作者原意。

### DIFF
--- a/chassis/chassis.c
+++ b/chassis/chassis.c
@@ -90,8 +90,7 @@ rt_err_t chassis_set_velocity(chassis_t chas, struct velocity target_velocity)
 {
     RT_ASSERT(chas != RT_NULL);
 
-    rt_int16_t res_rpm[4];
-    kinematics_get_rpm(*chas->c_kinematics, target_velocity, res_rpm);
+    rt_int16_t* res_rpm = kinematics_get_rpm(*chas->c_kinematics, target_velocity);
     chassis_set_rpm(chas, res_rpm);
 
     return RT_EOK;
@@ -131,8 +130,7 @@ rt_err_t chassis_straight(chassis_t chas, float linear_x)
         .linear_y = 0.0f,
         .angular_z = 0.0f
     };
-    rt_int16_t res_rpm[4];
-    kinematics_get_rpm(*chas->c_kinematics, target_velocity, res_rpm);
+    rt_int16_t* res_rpm = kinematics_get_rpm(*chas->c_kinematics, target_velocity);
     return chassis_set_rpm(chas, res_rpm);
 }
 
@@ -145,8 +143,7 @@ rt_err_t chassis_move(chassis_t chas, float linear_y)
         .linear_y = linear_y,
         .angular_z = 0.0f
     };
-    rt_int16_t res_rpm[4];
-    kinematics_get_rpm(*chas->c_kinematics, target_velocity, res_rpm);
+    rt_int16_t* res_rpm = kinematics_get_rpm(*chas->c_kinematics, target_velocity);
     return chassis_set_rpm(chas, res_rpm);
 }
 
@@ -159,8 +156,7 @@ rt_err_t chassis_rotate(chassis_t chas, float angular_z)
         .linear_y = 0.0f,
         .angular_z = angular_z
     };
-    rt_int16_t res_rpm[4];
-    kinematics_get_rpm(*chas->c_kinematics, target_velocity, res_rpm);
+    rt_int16_t* res_rpm = kinematics_get_rpm(*chas->c_kinematics, target_velocity);
     return chassis_set_rpm(chas, res_rpm);
 }
 
@@ -169,8 +165,7 @@ rt_err_t chassis_set_velocity_x(chassis_t chas, float linear_x)
     RT_ASSERT(chas != RT_NULL);
 
     chas->c_velocity.linear_x = linear_x;
-    rt_int16_t res_rpm[4];
-    kinematics_get_rpm(*chas->c_kinematics, chas->c_velocity, res_rpm);
+    rt_int16_t* res_rpm = kinematics_get_rpm(*chas->c_kinematics, chas->c_velocity);
     return chassis_set_rpm(chas, res_rpm);
 }
 
@@ -179,8 +174,7 @@ rt_err_t chassis_set_velocity_y(chassis_t chas, float linear_y)
     RT_ASSERT(chas != RT_NULL);
 
     chas->c_velocity.linear_y = linear_y;
-    rt_int16_t res_rpm[4];
-    kinematics_get_rpm(*chas->c_kinematics, chas->c_velocity, res_rpm);
+    rt_int16_t* res_rpm = kinematics_get_rpm(*chas->c_kinematics, chas->c_velocity);
     return chassis_set_rpm(chas, res_rpm);
 }
 
@@ -189,7 +183,6 @@ rt_err_t chassis_set_velocity_z(chassis_t chas, float angular_z)
     RT_ASSERT(chas != RT_NULL);
     
     chas->c_velocity.angular_z = angular_z;
-    rt_int16_t res_rpm[4];
-    kinematics_get_rpm(*chas->c_kinematics, chas->c_velocity, res_rpm);
+    rt_int16_t* res_rpm = kinematics_get_rpm(*chas->c_kinematics, chas->c_velocity);
     return chassis_set_rpm(chas, res_rpm);
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -237,7 +237,7 @@ kinematics_t    kinematics_create(enum base k_base, float length_x, float length
 | k_base  | 类型 |
 | length_x | X轴两轮间距 |
 | length_y | Y轴两轮间距 |
-| wheel_radius | 车轮直径 |
+| wheel_radius | 车轮半径 |
 | **返回** | **--**             |
 |   |  |
 

--- a/kinematics/kinematics.h
+++ b/kinematics/kinematics.h
@@ -44,7 +44,7 @@ struct kinematics
     enum base   k_base;
     float       length_x;
     float       length_y;
-    float       wheel_radius;
+    float       circumference;
     int         total_wheels;
 };
 
@@ -52,7 +52,7 @@ kinematics_t    kinematics_create(enum base k_base, float length_x, float length
 void            kinematics_destroy(kinematics_t kinematics);
 rt_err_t        kinematics_reset(kinematics_t kin);
 
-void            kinematics_get_rpm(struct kinematics kin, struct velocity target_vel, rt_int16_t *rpm);
-void            kinematics_get_velocity(struct kinematics kin, struct rpm current_rpm, struct velocity *velocity);
+rt_int16_t*     kinematics_get_rpm(struct kinematics kin, struct velocity target_vel);
+struct velocity kinematics_get_velocity(struct kinematics kin, struct rpm current_rpm);
 
 #endif


### PR DESCRIPTION
2.kinematics_get_rpm函数中动态申请内存后并没有释放,会造成内存消耗。作为存储转换后的rpm值只需要申请一次后可重复使用，故移动到了kinematics_create函数中。
2.kinematics_get_rpm和kinematics_get_velocity函数中circumference替换wheel_radius即可修正计算错误的问题。
3.api.md文档中wheel_radius的值实际作为半径计算的。